### PR TITLE
fix: ACI-5253 restore the relocated SPM checkouts when Build Cache for Xcode is active

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -14,6 +14,9 @@ import (
 
 const stepId = "restore-spm-cache"
 
+// EnvSwiftPackagesPath is exported by `bitrise-build-cache activate xcode`.
+const EnvSwiftPackagesPath = "BITRISE_XCODE_SOURCE_PACKAGES_PATH"
+
 // Cache key templates
 // OS + Arch: SPM works on Linux too, and Intel/ARM difference is important on macOS
 // checksum: Package.resolved is the dependency lockfile, either in the project root (pure Swift project)
@@ -21,6 +24,22 @@ const stepId = "restore-spm-cache"
 var keys = []string{
 	`{{ .OS }}-{{ .Arch }}-spm-cache-{{ checksum "**/Package.resolved" }}`,
 	`{{ .OS }}-{{ .Arch }}-spm-cache-`,
+}
+
+// Build Cache for Xcode relocates DerivedData and the SPM checkouts with it, so those archives hold
+// different absolute paths and restore replays an archive to its recorded paths. The marker sits
+// before "spm-cache" to keep both namespaces clear of each other's prefix fallback.
+var xcelerateKeys = []string{
+	`{{ .OS }}-{{ .Arch }}-xcelerate-spm-cache-{{ checksum "**/Package.resolved" }}`,
+	`{{ .OS }}-{{ .Arch }}-xcelerate-spm-cache-`,
+}
+
+func cacheKeys(envRepo env.Repository) []string {
+	if strings.TrimSpace(envRepo.Get(EnvSwiftPackagesPath)) != "" {
+		return xcelerateKeys
+	}
+
+	return keys
 }
 
 type Input struct {
@@ -56,9 +75,10 @@ func (step RestoreCacheStep) Run() error {
 		return fmt.Errorf("failed to parse inputs: %w", err)
 	}
 	stepconf.Print(input)
+	activeKeys := cacheKeys(step.envRepo)
 	step.logger.Println()
 	step.logger.Printf("Cache keys:")
-	step.logger.Printf(strings.Join(keys, "\n"))
+	step.logger.Printf(strings.Join(activeKeys, "\n"))
 	step.logger.Println()
 
 	step.logger.EnableDebugLog(input.Verbose)
@@ -67,7 +87,7 @@ func (step RestoreCacheStep) Run() error {
 	return restorer.Restore(cache.RestoreCacheInput{
 		StepId:         stepId,
 		Verbose:        input.Verbose,
-		Keys:           keys,
+		Keys:           activeKeys,
 		Timeout:        time.Duration(input.Timeout) * time.Second,
 		NumFullRetries: input.Retries,
 	})

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,0 +1,49 @@
+package step
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+)
+
+type fakeEnvRepo struct {
+	env.Repository
+	envs map[string]string
+}
+
+func (r fakeEnvRepo) Get(key string) string { return r.envs[key] }
+
+func TestCacheKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     []string
+	}{
+		{name: "default layout", envValue: "", want: keys},
+		{name: "relocated by Build Cache for Xcode", envValue: "/Users/vagrant/.bitrise/cache/xcode-spm", want: xcelerateKeys},
+		{name: "blank env var falls back to the default layout", envValue: "   ", want: keys},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cacheKeys(fakeEnvRepo{envs: map[string]string{EnvSwiftPackagesPath: tt.envValue}})
+
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("cacheKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Neither namespace may sit under the other's prefix fallback, or one layout restores over the other.
+func TestNamespacesAreDisjoint(t *testing.T) {
+	defaultPrefix, xceleratePrefix := keys[1], xcelerateKeys[1]
+
+	if strings.HasPrefix(xcelerateKeys[0], defaultPrefix) {
+		t.Errorf("xcelerate key %q is matched by the default prefix fallback %q", xcelerateKeys[0], defaultPrefix)
+	}
+	if strings.HasPrefix(keys[0], xceleratePrefix) {
+		t.Errorf("default key %q is matched by the xcelerate prefix fallback %q", keys[0], xceleratePrefix)
+	}
+}


### PR DESCRIPTION
Part of [ACI-5253](https://bitrise.atlassian.net/browse/ACI-5253). Found while investigating [ACI-5247](https://bitrise.atlassian.net/browse/ACI-5247) (Maven Clinic).

**Draft** — depends on bitrise-io/bitrise-build-cache-cli#445, which introduces the `BITRISE_XCODE_SOURCE_PACKAGES_PATH` export this Step reads.

**This Step ships first**, before bitrise-steplib/bitrise-step-save-spm-cache#15. See the ordering note below.

## Problem

`activate-build-cache-for-xcode` relocates DerivedData to `~/.bitrise/cache/xcode-dd/<workspace-sha>`, and SPM checkouts follow it. Archives taken from the relocated layout hold different absolute paths than default-layout ones, and restore replays an archive to its recorded paths — so the two layouts cannot share a key namespace.

## Change

Use an xcelerate key namespace when `BITRISE_XCODE_SOURCE_PACKAGES_PATH` is exported, and the existing keys otherwise. Workspaces not using Build Cache for Xcode are unaffected.

The marker sits **before** `spm-cache` rather than after:

```
darwin-arm64-spm-cache-<checksum>              default exact
darwin-arm64-spm-cache-                        default prefix fallback
darwin-arm64-xcelerate-spm-cache-<checksum>    xcelerate exact
darwin-arm64-xcelerate-spm-cache-              xcelerate prefix fallback
```

`darwin-arm64-spm-cache-xcelerate-…` would have been matched by the default prefix fallback, so a non-xcelerate build could restore a relocated-layout archive. With the marker first the two namespaces are disjoint in both directions, which `TestNamespacesAreDisjoint` pins down.

## Why this Step ships first

Saving first does not work. `save-spm-cache` passes `IsKeyUnique: true`, and `canSkipSave` in go-steputils returns early when the same evaluated key was restored during the build:

```go
if _, ok := cacheHits[evaluatedKey]; ok {
    if isKeyUnique { return true, reasonRestoreSameUniqueKey }
}
```

So with an old restore Step still deployed, the stale archive gets restored under the old key every build, the save is skipped, and the corrected archive never uploads. Writing both keys would need `IsKeyUnique: false` plus a second multi-GB upload per build.

Restoring first has no such problem. Until save lands, this Step looks in the xcelerate namespace, misses, and the build resolves from origin — which is exactly what affected workspaces get today, since their SPM cache is currently a silent no-op. No regression, and the moment save ships the namespace starts filling.

Release order: bitrise-io/bitrise-build-cache-cli#445 → **this** → bitrise-steplib/bitrise-step-save-spm-cache#15.

## Testing

`go build ./...`, `go vet ./step/...` and `go test ./step/...` pass. Tests cover namespace selection (env set / unset / blank) and the disjointness property above.

Tests use stdlib `testing` — the repo vendors its dependencies and testify is not among them, so `vendor/` stays untouched.

Not yet run end-to-end against a real SPM project with Build Cache for Xcode active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5253]: https://bitrise.atlassian.net/browse/ACI-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACI-5247]: https://bitrise.atlassian.net/browse/ACI-5247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ